### PR TITLE
Fix misspelled include in CAN module

### DIFF
--- a/Platform/CAN/src/taskCANcommunicationJ1939.c
+++ b/Platform/CAN/src/taskCANcommunicationJ1939.c
@@ -20,7 +20,7 @@
 #include "debug.h"
 #include "platformAPI.h"
 #include "osresources.h"
-#include "indices.h"
+#include "Indices.h"
 #include "UserConfiguration.h"
 #include "UserMessagingCAN.h"
 #include "sensors_data.h"


### PR DESCRIPTION
Hi,
trying to build some examples for `OpenIMU300RI` I found a misspelled header in the CAN module, so I fixed it and now it compiles correctly.
Hope this can be helpful.